### PR TITLE
Rename organization from base16-project to tinted-theming

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
 We've recently changed our name to [tinted-theming](https://github.com/tinted-theming) to avoid any confusion with Chris Kempson's [Base16](https://github.com/chriskempson/base16) project.
 
-For the full story please see our post [Base16 Project Lives On (soon to be renamed)](https://github.com/tinted-theming/base16/issues/51).
+For the full story please see our post [Base16 Project Lives On](https://github.com/tinted-theming/base16/issues/51).
 
 Also a big thank you to all of you who have been so enthusiastic and involved in the new organization.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-We've recently changed our name from [tinted-theming](https://github.com/tinted-theming) to avoid any confusion with Chris Kempson's [Base16](https://github.com/chriskempson/base16) project.
+We've recently changed our name to [tinted-theming](https://github.com/tinted-theming) to avoid any confusion with Chris Kempson's [Base16](https://github.com/chriskempson/base16) project.
 
 For the full story please see our post [Base16 Project Lives On (soon to be renamed)](https://github.com/tinted-theming/base16/issues/51).
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,5 @@
-We've recently changed our name from [base16-project](https://github.com/base16-project) to avoid any confusion with Chris Kempson's [Base16](https://github.com/chriskempson/base16) project.
+We've recently changed our name from [tinted-theming](https://github.com/tinted-theming) to avoid any confusion with Chris Kempson's [Base16](https://github.com/chriskempson/base16) project.
 
-For the full story please see our post [Base16 Project Lives On (soon to be renamed)](https://github.com/base16-project/base16/issues/51).
+For the full story please see our post [Base16 Project Lives On (soon to be renamed)](https://github.com/tinted-theming/base16/issues/51).
 
 Also a big thank you to all of you who have been so enthusiastic and involved in the new organization.


### PR DESCRIPTION
Base16-project had announced that it was [going to change their name in July](https://github.com/tinted-theming/home/issues/51). [After a bit of effort](https://github.com/tinted-theming/home/issues/38), we've finally renamed the organization.

This PR updates references to base16-project and also updates the license.